### PR TITLE
Make query object extendable

### DIFF
--- a/odata/query.py
+++ b/odata/query.py
@@ -170,7 +170,7 @@ class Query(Generic[Q]):
         o['$filter'] = self.options.get('$filter', [])[:]
         o['$expand'] = self.options.get('$expand', [])[:]
         o['$orderby'] = self.options.get('$orderby', [])[:]
-        return Query[Q](self.entity, options=o, connection=self.connection)
+        return self.__class__[Q](self.entity, options=o, connection=self.connection)
 
     def as_string(self) -> str:
         query = self._format_params(self._get_options())


### PR DESCRIPTION
Currently the Query object has a hardcoded link to itself within `_new_query`. This MR changes this by using the `self.__class__`, which makes it easier to extend the query object to add additional methods within your own project.