### PR TITLE
Fix query string encoding according to the odata-v4.01-part2-url-conv…

### DIFF
--- a/odata/connection.py
+++ b/odata/connection.py
@@ -6,6 +6,7 @@ import logging
 
 import requests
 from requests.exceptions import RequestException
+from urllib.parse import urlencode, quote
 
 from odata import version
 from .exceptions import ODataError, ODataConnectionError
@@ -40,6 +41,8 @@ class ODataConnection(object):
 
     def _apply_options(self, kwargs):
         kwargs['timeout'] = self.timeout
+        if "params" in kwargs and kwargs["params"]:
+            kwargs["params"] = urlencode(kwargs["params"], quote_via=quote)
 
         if self.auth is not None:
             kwargs['auth'] = self.auth


### PR DESCRIPTION
…entions, part 2.1 URL Parsing

Percent-decode path segments, query option names, and query option values exactly once

Background: requests library uses "+" sign instead of "%20" which collides with odata specification. Instead of using quote_via=quote_plus, odata library has to use the quote_via=quote function to match the odata specification

Reference
http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html#sec_URLParsing