### PR TITLE
Provide support for contextually-readonly properties, and odata services which don't follow Foreign Key BINDs

### DIFF
--- a/odata/connection.py
+++ b/odata/connection.py
@@ -180,7 +180,7 @@ class ODataConnection(object):
         data = json.dumps(data)
 
         self.log.info(u'PATCH {0}'.format(url))
-        self.log.info(u'Payload: {0}'.format(data))
+        # self.log.info(u'Payload: {0}'.format(data))
 
         response = self._do_patch(url, data=data, headers=headers)
         self._handle_odata_error(response)

--- a/odata/connection.py
+++ b/odata/connection.py
@@ -156,8 +156,8 @@ class ODataConnection(object):
         if not raw:
             data = json.dumps(data)
 
-        self.log.info(u'POST {0}'.format(url))
-        self.log.info(u'Payload: {0}'.format(data))
+        # self.log.info(u'POST {0}'.format(url))
+        # self.log.info(u'Payload: {0}'.format(data))
 
         response = self._do_post(url, data=data, headers=headers, params=params)
         self._handle_odata_error(response)

--- a/odata/context.py
+++ b/odata/context.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import logging
+from typing import Union
 
 from odata.query import Query
 from odata.connection import ODataConnection
@@ -49,7 +50,7 @@ class Context:
         entity.__odata__.persisted = False
         self.log.info(u'Success')
 
-    def save(self, entity, force_refresh=True, extra_headers=None, omit_null_props=[]):
+    def save(self, entity, force_refresh: bool = True, extra_headers=None, omit_null_props: Union[bool, list[str]] = False):
         """
         Creates a POST or PATCH call to the service. If the entity already has
         a primary key, an update is called. Otherwise the entity is inserted
@@ -58,6 +59,8 @@ class Context:
         :param entity: Model instance to insert or update
         :type entity: EntityBase
         :param force_refresh: Read full entity data again from service after PATCH call
+        :param omit_null_props: True/False or a list of properties to omit.
+            If set to true or given a list of properties these will be ommited from the request if they're set to None/null
         :param extra_headers: Add custom headers on patch, post (Example:B1S-ReplaceCollectionsOnPatch=true)
         :raises ODataConnectionError: Invalid data or serverside error. Server returned an HTTP error code
         """
@@ -70,7 +73,7 @@ class Context:
     def is_entity_saved(self, entity):
         return entity.__odata__.persisted
 
-    def _insert_new(self, entity, omit_null_props=[]):
+    def _insert_new(self, entity, omit_null_props: Union[bool, list[str]] = False):
         """
         Creates a POST call to the service, sending the complete new entity
 
@@ -95,7 +98,7 @@ class Context:
 
         self.log.info(u'Success')
 
-    def _update_existing(self, entity, force_refresh=True, extra_headers=None, omit_null_props=[]):
+    def _update_existing(self, entity, force_refresh=True, extra_headers=None, omit_null_props: Union[bool, list[str]] = False):
         """
         Creates a PATCH call to the service, sending only the modified values
 

--- a/odata/service.py
+++ b/odata/service.py
@@ -56,7 +56,7 @@ import importlib
 import logging
 import sys
 import urllib.parse
-from typing import Optional, TypeVar
+from typing import Optional, TypeVar, Union
 
 import rich
 import rich.console
@@ -244,13 +244,15 @@ class ODataService(object):
         """
         return self.default_context.delete(entity)
 
-    def save(self, entity, force_refresh=True, omit_null_props=[]):
+    def save(self, entity, force_refresh=True, omit_null_props: Union[bool, list[str]] = False):
         """
         Creates a POST or PATCH call to the service. If the entity already has
         a primary key, an update is called. Otherwise the entity is inserted
         as new. Updating an entity will only send the changed values
 
         :param entity: Model instance to insert or update
+        :param omit_null_props: True/False or a list of properties to omit.
+            If set to true or given a list of properties these will be ommited from the request if they're set to None/null
         :param force_refresh: Read full entity data again from service after PATCH call
         :raises ODataConnectionError: Invalid data or serverside error. Server returned an HTTP error code
         """

--- a/odata/service.py
+++ b/odata/service.py
@@ -244,7 +244,7 @@ class ODataService(object):
         """
         return self.default_context.delete(entity)
 
-    def save(self, entity, force_refresh=True):
+    def save(self, entity, force_refresh=True, omit_null_props=[]):
         """
         Creates a POST or PATCH call to the service. If the entity already has
         a primary key, an update is called. Otherwise the entity is inserted
@@ -254,4 +254,4 @@ class ODataService(object):
         :param force_refresh: Read full entity data again from service after PATCH call
         :raises ODataConnectionError: Invalid data or serverside error. Server returned an HTTP error code
         """
-        return self.default_context.save(entity, force_refresh=force_refresh)
+        return self.default_context.save(entity, force_refresh=force_refresh, omit_null_props=omit_null_props)

--- a/odata/state.py
+++ b/odata/state.py
@@ -259,6 +259,14 @@ class EntityState(object):
                 else:
                     if value.__odata__.id:
                         insert_data['{0}@odata.bind'.format(prop.name)] = value.__odata__.id
+                        
+                        # Put the foreign key back into the request for compatibility with 
+                        #   systems that don't handle {entity} odata.bind correctly
+                        try:
+                            insert_data[prop.foreign_key] = getattr(value, prop.foreign_key)
+                        except:
+                           pass
+
                     else:
                         insert_data[prop.name] = self._clean_new_entity(value)
 

--- a/odata/state.py
+++ b/odata/state.py
@@ -216,7 +216,7 @@ class EntityState(object):
 
     @staticmethod
     def _filter_null_properties(properties: dict, omit_null_props: Union[bool, list[str]]) -> dict:
-        if omit_null_props is True or len(omit_null_props) > 0:
+        if omit_null_props is True or (type(omit_null_props) == list and len(omit_null_props) > 0):
             filtered_properties = {}
             for prop_name, prop in properties.items():
                 if omit_null_props is True or prop_name in omit_null_props:

--- a/odata/state.py
+++ b/odata/state.py
@@ -188,10 +188,10 @@ class EntityState(object):
         if prop.name not in self.dirty:
             self.dirty.append(prop.name)
 
-    def data_for_insert(self):
-        return self._clean_new_entity(self.entity)
+    def data_for_insert(self, omit_null_props=[]):
+        return self._clean_new_entity(self.entity, omit_null_props)
 
-    def data_for_update(self):
+    def data_for_update(self, omit_null_props=[]):
         update_data = OrderedDict()
         update_data['@odata.type'] = self.entity.__odata_type__
 
@@ -211,9 +211,19 @@ class EntityState(object):
                         update_data[key] = [i.__odata__.id for i in value]
                     else:
                         update_data[key] = value.__odata__.id
-        return update_data
+        
+        update_data_filtered = {}
+        for prop_name, prop in update_data.items():
+            if omit_null_props is True or prop_name in omit_null_props:
+                # Should omit unless not None
+                if prop is None:
+                    # Omit from request
+                    continue
+                update_data_filtered[prop_name] = prop
 
-    def _clean_new_entity(self, entity):
+        return update_data_filtered
+
+    def _clean_new_entity(self, entity, omit_null_props=[]):
         """:type entity: odata.entity.EntityBase """
         insert_data = OrderedDict()
         insert_data['@odata.type'] = entity.__odata_type__
@@ -262,4 +272,13 @@ class EntityState(object):
                     else:
                         insert_data[prop.name] = self._clean_new_entity(value)
 
-        return insert_data
+        insert_data_filtered = {}
+        for prop_name, prop in insert_data.items():
+            if omit_null_props is True or prop_name in omit_null_props:
+                # Should omit unless not None
+                if prop is None:
+                    # Omit from request
+                    continue
+                insert_data_filtered[prop_name] = prop
+
+        return insert_data_filtered


### PR DESCRIPTION
These tweaks solve issues with support for SAP Business One's Service Layer. All edits welcome. I don't believe these changes have adverse impacts for other services, and are likely workarounds for problems in SAP B1. They solved my problems, but YMMV - more testing encouraged.