### PR TITLE
Need enum name in escaped value

### DIFF
--- a/odata/connection.py
+++ b/odata/connection.py
@@ -28,15 +28,15 @@ class ODataConnection(object):
         'OData-Version': '4.0',
         'User-Agent': 'python-odata {0}'.format(version),
     }
-    timeout = 90
 
-    def __init__(self, session=None, auth=None, extra_headers: dict = None):
+    def __init__(self, session=None, auth=None, extra_headers: dict = None, timeout=90):
         if session is None:
             self.session = requests.Session()
         else:
             self.session = session
         self.auth = auth
         self.log = logging.getLogger('odata.connection')
+        self.timeout = timeout
 
         self.extra_headers = extra_headers
 

--- a/odata/context.py
+++ b/odata/context.py
@@ -9,9 +9,9 @@ from odata.flags import ODataServerFlags
 
 
 class Context:
-    def __init__(self, session=None, auth=None, extra_headers: dict = None, server_flags: ODataServerFlags = None):
+    def __init__(self, session=None, auth=None, extra_headers: dict = None, server_flags: ODataServerFlags = None, timeout=90):
         self.log = logging.getLogger('odata.context')
-        self.connection = ODataConnection(session=session, auth=auth, extra_headers=extra_headers)
+        self.connection = ODataConnection(session=session, auth=auth, extra_headers=extra_headers, timeout=timeout)
         self.server_flags = server_flags
 
     def query(self, entitycls):

--- a/odata/enumtype.py
+++ b/odata/enumtype.py
@@ -21,6 +21,11 @@ class EnumTypeProperty(PropertyBase):
         super(EnumTypeProperty, self).__init__(name)
         self.enum_class = enum_class
 
+    def escape_value(self, value):
+        if self.enum_class.__module__:
+            return f"{self.enum_class.__module__}.{self.enum_class.__name__}'{value.name}'"
+        return f"{self.enum_class.__name__}'{value.name}'"
+
     def serialize(self, value):
         return value.name
 

--- a/odata/reflector.py
+++ b/odata/reflector.py
@@ -94,7 +94,7 @@ type_translations = {
     "FloatProperty": "float",
     "BooleanProperty": "bool",
     "UUIDProperty": "uuid.UUID",
-    "EnumTypeProperty": "str"
+    "EnumTypeProperty": "Enum"
 }
 
 

--- a/odata/service.py
+++ b/odata/service.py
@@ -91,6 +91,7 @@ class ODataService(object):
     :param auth: Custom Requests auth object to use for credentials
     :param console: Rich console instance to use for messages. If set to None a new console will be created. Console will inherit quiet flag from quiet_progress.
     :param quiet_progress: Don't show any progress information while reflecting metadata and while other long duration tasks are running. Default is to show progress
+    :param server_flags: Server specific flags for an OData server
     :raises ODataConnectionError: Fetching metadata failed. Server returned an HTTP error code
     """
 

--- a/odata/service.py
+++ b/odata/service.py
@@ -92,6 +92,7 @@ class ODataService(object):
     :param console: Rich console instance to use for messages. If set to None a new console will be created. Console will inherit quiet flag from quiet_progress.
     :param quiet_progress: Don't show any progress information while reflecting metadata and while other long duration tasks are running. Default is to show progress
     :param server_flags: Server specific flags for an OData server
+    :param timeout: Connection timeout
     :raises ODataConnectionError: Fetching metadata failed. Server returned an HTTP error code
     """
 
@@ -105,13 +106,14 @@ class ODataService(object):
                  auth=None,
                  console: rich.console.Console = None,
                  quiet_progress: bool = False,
-                 server_flags: ODataServerFlags = ODataServerFlags()):
+                 server_flags: ODataServerFlags = ODataServerFlags(),
+                 timeout=90):
         self.url = url if url.endswith("/") else url + "/"  # make sure url ends with / otherwise we have problems
         self.metadata_url = urllib.parse.urljoin(self.url, "$metadata")
         self.collections = {}
         self.log = logging.getLogger('odata.service')
         self.server_flags = server_flags
-        self.default_context = Context(auth=auth, session=session, extra_headers=extra_headers, server_flags=server_flags)
+        self.default_context = Context(auth=auth, session=session, extra_headers=extra_headers, server_flags=server_flags, timeout=timeout)
         self.console = console if console is not None else rich.console.Console(quiet=quiet_progress)
         self.quiet_progress = quiet_progress
 
@@ -204,17 +206,18 @@ class ODataService(object):
         outputter = MetadataReflector(metadata_url=metadata_url, entities=self.entities, types=self.types, package=package, quiet=self.quiet_progress)
         outputter.write_reflected_types()
 
-    def create_context(self, auth=None, session=None, extra_headers: dict = None):
+    def create_context(self, auth=None, session=None, extra_headers: dict = None, timeout=90):
         """
         Create new context to use for session-like usage
 
         :param auth: Custom Requests auth object to use for credentials
         :param session: Custom Requests session to use for communication with the endpoint
         :param extra_headers: Any extra headers to pass to use for all communications
+        :param timeout: Connection timeout
         :return: Context instance
         :rtype: Context
         """
-        return Context(auth=auth, session=session, extra_headers=extra_headers, server_flags=self.server_flags)
+        return Context(auth=auth, session=session, extra_headers=extra_headers, server_flags=self.server_flags, timeout=timeout)
 
     def describe(self, entity) -> None:
         """

--- a/odata/state.py
+++ b/odata/state.py
@@ -244,9 +244,6 @@ class EntityState(object):
 
         # Deep insert from nav properties
         for prop_name, prop in es.navigation_properties:
-            if prop.foreign_key:
-                insert_data.pop(prop.foreign_key, None)
-
             value = getattr(entity, prop_name, None)
             """:type : None | odata.entity.EntityBase | list[odata.entity.EntityBase]"""
             if value is not None:


### PR DESCRIPTION
When we query MS Dynamics with odata, we need the enum name in the escaped value. Now we get:
`https://mg-prod.operations.dynamics.com/data/Projects?$filter=ProjectStage eq ProjStatus.InProcess`
but we need
`https://mg-prod.operations.dynamics.com/data/Projects?$filter=ProjectStage eq Microsoft.Dynamics.DataEntities.ProjStatus'InProcess'`

So in addition to this patch, when we reflect we also need to get the fully qualified name into the enum. Not:
`Enum("ProjStatus", ...)`
but:
`Enum("Microsoft.Dynamics.DataEntities.ProjStatus", ...)`

And I guess that
`ProjectStage: str = EnumTypeProperty("ProjectStage", enum_class=ProjStatus)`
should be
`ProjectStage: Enum = EnumTypeProperty("ProjectStage", enum_class=ProjStatus)`
?

If you don't have access to a system with enums, I can test changes if you need any.