### PR TITLE
Customizable payloads for update and insert

### DIFF
--- a/odata/flags.py
+++ b/odata/flags.py
@@ -1,0 +1,8 @@
+
+from dataclasses import dataclass
+
+@dataclass
+class ODataServerFlags:
+  skip_null_properties: bool = False
+  provide_odata_type_annotation: bool = True
+  odata_bind_requires_slash: bool = False

--- a/odata/service.py
+++ b/odata/service.py
@@ -66,6 +66,7 @@ from .metadata import MetaData
 from .exceptions import ODataError
 from .context import Context
 from .action import Action, Function
+from .flags import ODataServerFlags
 
 __all__ = (
     'ODataService',
@@ -101,12 +102,13 @@ class ODataService(object):
                  extra_headers: dict = None,
                  auth=None,
                  console: rich.console.Console = None,
-                 quiet_progress: bool = False):
+                 quiet_progress: bool = False,
+                 server_flags: ODataServerFlags=ODataServerFlags()):
         self.url = url if url.endswith("/") else url + "/"  # make sure url ends with / otherwise we have problems
         self.metadata_url = urllib.parse.urljoin(self.url, "$metadata")
         self.collections = {}
         self.log = logging.getLogger('odata.service')
-        self.default_context = Context(auth=auth, session=session, extra_headers=extra_headers)
+        self.default_context = Context(auth=auth, session=session, extra_headers=extra_headers, server_flags=server_flags)
         self.console = console if console is not None else rich.console.Console(quiet=quiet_progress)
         self.quiet_progress = quiet_progress
 

--- a/odata/state.py
+++ b/odata/state.py
@@ -17,10 +17,6 @@ from odata.property import PropertyBase, NavigationProperty
 
 class EntityState(object):
 
-    ODATA_BIND_REQUIRES_SLASH: bool = False
-    ODATA_TYPE_REQUIRED: bool = True
-    ODATA_REMOVE_EMPTY_PARAMS: bool = False
-
     def __init__(self, entity):
         """:type entity: EntityBase """
         self.entity: "EntityBase" = entity

--- a/odata/state.py
+++ b/odata/state.py
@@ -11,6 +11,7 @@ import rich
 import rich.panel
 import rich.table
 
+from odata.flags import ODataServerFlags
 from odata.property import PropertyBase, NavigationProperty
 
 
@@ -188,21 +189,21 @@ class EntityState(object):
                 rv.append((prop_name, prop))
         return rv
     
-    def _format_odata_bind_key(self, prop_name):
+    def _format_odata_bind_key(self, prop_name, require_slash: bool = False):
         key = '{0}@odata.bind'.format(prop_name)
-        key = f'/{key}' if type(self).ODATA_BIND_REQUIRES_SLASH else key
+        key = f'/{key}' if require_slash else key
         return key
 
     def set_property_dirty(self, prop):
         if prop.name not in self.dirty:
             self.dirty.append(prop.name)
 
-    def data_for_insert(self):
-        return self._clean_new_entity(self.entity)
+    def data_for_insert(self, server_flags: ODataServerFlags):
+        return self._clean_new_entity(self.entity, server_flags)
 
-    def data_for_update(self):
+    def data_for_update(self, server_flags: ODataServerFlags):
         update_data = OrderedDict()
-        if type(self).ODATA_TYPE_REQUIRED:
+        if server_flags.provide_odata_type_annotation:
             update_data['@odata.type'] = self.entity.__odata_type__
 
         for _, prop in self.dirty_properties:
@@ -216,21 +217,21 @@ class EntityState(object):
                 value = getattr(self.entity, prop_name, None)  # get the related object
                 """:type : None | odata.entity.EntityBase | list[odata.entity.EntityBase]"""
                 if value is not None:
-                    key = self._format_odata_bind_key(prop.name)
+                    key = self._format_odata_bind_key(prop.name, server_flags.odata_bind_requires_slash)
                     if prop.is_collection:
                         update_data[key] = [i.__odata__.id for i in value]
                     else:
                         update_data[key] = value.__odata__.id
 
-        if type(self).ODATA_REMOVE_EMPTY_PARAMS:
-            update_data = _remove_empties(update_data)
+        if server_flags.skip_null_properties:
+            update_data = _remove_null_properties(update_data)
 
         return update_data
 
-    def _clean_new_entity(self, entity):
+    def _clean_new_entity(self, entity, server_flags: ODataServerFlags):
         """:type entity: odata.entity.EntityBase """
         insert_data = OrderedDict()
-        if type(self).ODATA_TYPE_REQUIRED:
+        if server_flags.provide_odata_type_annotation:
             insert_data['@odata.type'] = entity.__odata_type__
 
         es = entity.__odata__
@@ -262,29 +263,29 @@ class EntityState(object):
                         binds.append(i.__odata__.id)
 
                     if len(binds):
-                        key = self._format_odata_bind_key(prop.name)
+                        key = self._format_odata_bind_key(prop.name, server_flags.odata_bind_requires_slash)
                         insert_data[key] = binds
 
                     new_entities = []
                     for i in [i for i in value if i.__odata__.id is None]:
-                        new_entities.append(self._clean_new_entity(i))
+                        new_entities.append(self._clean_new_entity(i, server_flags))
 
                     if len(new_entities):
                         insert_data[prop.name] = new_entities
 
                 else:
                     if value.__odata__.id:
-                        key = self._format_odata_bind_key(prop.name)
+                        key = self._format_odata_bind_key(prop.name, server_flags.odata_bind_requires_slash)
                         insert_data[key] = value.__odata__.id
                     else:
-                        insert_data[prop.name] = self._clean_new_entity(value)
+                        insert_data[prop.name] = self._clean_new_entity(value, server_flags)
 
-        if type(self).ODATA_REMOVE_EMPTY_PARAMS:
-            insert_data = _remove_empties(insert_data)
+        if server_flags.skip_null_properties:
+            insert_data = _remove_null_properties(insert_data)
 
         return insert_data
 
-def _remove_empties(data):
+def _remove_null_properties(data):
     for key in [key for key, value in data.items() if value is None]:
         del data[key]
     return data

--- a/odata/tests/test_actions.py
+++ b/odata/tests/test_actions.py
@@ -105,7 +105,7 @@ class TestFunctions(unittest.TestCase):
 
     def test_call_function_with_result_query(self):
         def request_callback(request):
-            self.assertTrue('filter=ProductName+eq+%27testtest%27' in request.url)
+            self.assertTrue('filter=%28ProductName%20eq%20%27testtest%27%29' in request.url)
 
             headers = {}
             body = dict(value='ok')

--- a/odata/tests/test_composite_keys.py
+++ b/odata/tests/test_composite_keys.py
@@ -57,12 +57,14 @@ class TestCompositeKeys(TestCase):
             sales_id = pm_sales.__odata__.id
             self.assertIn('ProductID=1', sales_id)
             self.assertIn('ManufacturerID=2', sales_id)
+            self.assertEqual(pm_sales.sales_amount, test_pm_sales_value["SalesAmount"])
+
+            sales_amount = 50.0
+            updated_values = {**test_pm_sales_value, "SalesAmount": sales_amount}
 
             rsps.add(rsps.PATCH, pm_sales.__odata__.instance_url,
-                     content_type='application/json')
-            rsps.add(rsps.GET, pm_sales.__odata__.instance_url,
                      content_type='application/json',
-                     json=dict(value=[test_pm_sales_value]))
+                     json=updated_values)
 
-            pm_sales.sales_amount = Decimal('50.0')
-            Service.save(pm_sales)
+            pm_sales.sales_amount = sales_amount
+            Service.save(pm_sales, force_refresh=False)

--- a/odata/tests/test_metadata.py
+++ b/odata/tests/test_metadata.py
@@ -19,7 +19,7 @@ class TestMetadataImport(TestCase):
 
     def test_read(self):
         with responses.RequestsMock() as rsps:
-            rsps.add(rsps.GET, 'http://demo.local/odata/$metadata/',
+            rsps.add(rsps.GET, 'http://demo.local/odata/$metadata',
                      body=metadata_xml, content_type='text/xml')
             Service = ODataService('http://demo.local/odata/', reflect_entities=True, quiet_progress=True)
 
@@ -47,7 +47,7 @@ class TestMetadataImport(TestCase):
 
     def test_computed_value_in_insert(self):
         with responses.RequestsMock() as rsps:
-            rsps.add(rsps.GET, 'http://demo.local/odata/$metadata/',
+            rsps.add(rsps.GET, 'http://demo.local/odata/$metadata',
                      body=metadata_xml, content_type='text/xml')
             Service = ODataService('http://demo.local/odata/', reflect_entities=True, quiet_progress=True)
 

--- a/odata/tests/test_nw_manual_model.py
+++ b/odata/tests/test_nw_manual_model.py
@@ -70,7 +70,7 @@ class NorthwindManualModelReadTest(unittest.TestCase):
         q = q.order_by(Customer.city.asc())
         data = q.all()
         assert data is not None, 'data is None'
-        assert len(data) > 20, 'data length wrong'
+        assert len(data) < 30, 'data length wrong'
 
     def test_iterating_query_result(self):
         q = service.query(Customer)

--- a/odata/tests/test_nw_reflect_and_generate_model.py
+++ b/odata/tests/test_nw_reflect_and_generate_model.py
@@ -36,7 +36,7 @@ class NorthwindAutomaticModelModelWithGenerationReadTest(unittest.TestCase):
         q = q.order_by(Customers.City.asc())
         data = q.all()
         assert data is not None, 'data is None'
-        assert len(data) > 20, 'data length wrong'
+        assert len(data) < 30, 'data length wrong'
 
     def test_iterating_query_result(self):
         q = service.query(Customers)


### PR DESCRIPTION
For discussion; my OData source fails inserts and updates when payloads:

1. contain `@odata.type` 
2. `@odata.bind`'s do not have a slash prefix
3. properties with empty values are included.

I had a look at an existing [PR](https://github.com/eblis/python-odata/pull/5) but have reservations as every single call to save or update must pass state and increase client code complexity. Instead, I created some Class properties in the EntityState class so that it's payload generation is customizable. These can be set once only in a session though I guess this approach would fail if more than one incompatible odata source were being used at the same time. A third possibility might be to pass parameters through the `ODataService`, store in the `Context` and pass to the `EntityState` that way.

Thoughts welcome, thank you.