### PR TITLE
Enable an update to handle returned state

### DIFF
--- a/odata/connection.py
+++ b/odata/connection.py
@@ -184,6 +184,12 @@ class ODataConnection(object):
 
         response = self._do_patch(url, data=data, headers=headers)
         self._handle_odata_error(response)
+        response_ct = response.headers.get('content-type', '')
+        if response.status_code == requests.codes.no_content:
+            return
+        if 'application/json' in response_ct:
+            return response.json()
+        # no exceptions here, PATCHing to Actions may not return data
 
     def execute_delete(self, url, extra_headers=None):
         headers = {}


### PR DESCRIPTION
My Odata system returns state from an update (PATCH) call. It makes sense to update the entity object with this and not need to make a separate call (_force_refresh=True_). The logic is the same as for an insert (POST) call.

As an aside, it may make sense to separate the _save_ method into _insert_ and _update_ calls as in order to make an update without first having to query for an entity before updating it. To achieve this, I had to set `Entity.__odata__.persisted = True` which seems too obsure for a general pattern.

```python
sample = odata_service.entities["SAMPLE"]()
sample.Barcode = "12345" # primary key
sample.HELLO = "world"    # property to update
sample.__odata__.persisted = True  # flag it already exists to force an update
odata_service.save(sample, force_refresh=False)
```