### PR TITLE
Enum filtering fix

### DIFF
--- a/odata/context.py
+++ b/odata/context.py
@@ -9,7 +9,7 @@ from odata.flags import ODataServerFlags
 
 
 class Context:
-    def __init__(self, session=None, auth=None, extra_headers: dict = None, server_flags: ODataServerFlags = None):
+    def __init__(self, session=None, auth=None, extra_headers: dict = None, server_flags: ODataServerFlags = ODataServerFlags()):
         self.log = logging.getLogger('odata.context')
         self.connection = ODataConnection(session=session, auth=auth, extra_headers=extra_headers)
         self.server_flags = server_flags

--- a/odata/enumtype.py
+++ b/odata/enumtype.py
@@ -21,6 +21,11 @@ class EnumTypeProperty(PropertyBase):
         super(EnumTypeProperty, self).__init__(name)
         self.enum_class = enum_class
 
+    def escape_value(self, value):
+        if self.enum_class.__module__:
+            return f"Microsoft.Dynamics.DataEntities.{self.enum_class.__name__}'{value.name}'"
+        return f"{self.enum_class.__name__}'{value.name}'"
+
     def serialize(self, value):
         return value.name
 

--- a/odata/reflect-templates/enum_entity.mako
+++ b/odata/reflect-templates/enum_entity.mako
@@ -1,5 +1,3 @@
-
-
 <%page args="name, entity"/>\
 <% short_name = name.split(".")[-1] %>\
 ${short_name} = Enum("${short_name}", {\

--- a/odata/reflector.py
+++ b/odata/reflector.py
@@ -94,7 +94,7 @@ type_translations = {
     "FloatProperty": "float",
     "BooleanProperty": "bool",
     "UUIDProperty": "uuid.UUID",
-    "EnumTypeProperty": "str"
+    "EnumTypeProperty": "Enum"
 }
 
 

--- a/odata/service.py
+++ b/odata/service.py
@@ -91,6 +91,7 @@ class ODataService(object):
     :param auth: Custom Requests auth object to use for credentials
     :param console: Rich console instance to use for messages. If set to None a new console will be created. Console will inherit quiet flag from quiet_progress.
     :param quiet_progress: Don't show any progress information while reflecting metadata and while other long duration tasks are running. Default is to show progress
+    :param server_flags: Server specific flags for an OData server
     :raises ODataConnectionError: Fetching metadata failed. Server returned an HTTP error code
     """
 


### PR DESCRIPTION
**This PR fixes a bug where filtering with enums did not work correctly.**

Now it would be possible to execute a filter like the following: `session.query(DimensionIntegrationFormats).filter(DimensionIntegrationFormats.DimensionFormatType == DimensionHierarchyType.DataEntityDefaultDimensionFormat).first()`.

> This query fetches the first DimensionIntegrationFormats record where the DimensionFormatType enum equals DimensionHierarchyType.DataEntityDefaultDimensionFormat.

It was tested in a DynamicsFO environment with enums and seems working.

I hope this can be merged soon — in the meantime, we'll be using a fork since we rely on this fix.

_This was based on https://github.com/eblis/python-odata/pull/7_

